### PR TITLE
SHARDS: Add readline dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /doc/
 /libs/
+/lib/
 /.crystal/
 /.shards/
 .json

--- a/shard.lock
+++ b/shard.lock
@@ -4,6 +4,10 @@ shards:
     github: DougEverly/daemonize.cr
     commit: 03d7da27fe76ee6b77d47a66984969a308a42027
 
+  readline:
+    github: crystal-lang/crystal-readline
+    version: 0.1.0
+
   webmock:
     github: manastech/webmock.cr
     commit: 8c1e360c80479f2708975334061c417332cbe89d

--- a/shard.yml
+++ b/shard.yml
@@ -7,6 +7,8 @@ authors:
 dependencies:
   daemonize:
     github: DougEverly/daemonize.cr
+  readline:
+    github: crystal-lang/crystal-readline
 
 development_dependencies:
   webmock:


### PR DESCRIPTION
fixes #2

Adds readline shard to the shard.yml file.

Additionally adds /lib/ to .gitignore (/libs/ was already there)

Signed-off-by: Mark Stenglein <mark@stengle.in>