### PR TITLE
CLI: Convert Indexable#at to Indexable#values_at

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -227,7 +227,7 @@ module BlackBoard::Dl
 
       # Error handling...
       begin
-        @@college = colleges.at(idx.to_s.to_i)
+        @@college = colleges.values_at(idx.to_s.to_i)[0]
         selected = true
       rescue
         puts "[x] That didn't work, try again...".colorize.red


### PR DESCRIPTION
closes #4 

Crystal removed the Indexable#at method at some point since 0.24.1.

This patch changes the call to Indexable#values_at

Signed-off-by: Mark Stenglein <mark@stengle.in>