### PR TITLE
CLIENT: Update XML::Type to XML::Node::Type

### DIFF
--- a/src/blackboard-dl/client.cr
+++ b/src/blackboard-dl/client.cr
@@ -166,7 +166,7 @@ module BlackBoard::Dl
 
           # Lecture Materials.
           child.children[3].children[1].children.each do |inner|
-            if inner.type == XML::Type::ELEMENT_NODE
+            if inner.type == XML::Node::Type::ELEMENT_NODE
               if inner.name == "attachments"
                 puts "  [+] #{course_name} lecture avaliable for #{week_name}.".colorize.green.to_s
                 # we need to go deeper.


### PR DESCRIPTION
fixes hako#6

Crystal made a breaking change, moving XML::Type to XML::Node::Type.

This patch fixes that issue.

Signed-off-by: Mark Stenglein <mark@stengle.in>